### PR TITLE
started adding build ecosystem for linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+#eclipse integration
+.project
+.cproject
+.settings
+#allows out of source build
+build*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,22 @@
+cmake_minimum_required (VERSION 3.1.0)
+project (rabbit)
+
+set (CMAKE_CXX_STANDARD 11)
+SET(BASE_PATH ${CMAKE_CURRENT_SOURCE_DIR})
+
+set(RABBIT_TIME_HASH_MAPS         0  CACHE BOOL   "time hash maps.")
+set(RABBIT_TESTS                  0  CACHE BOOL   "comparative tests.")
+set(RABBIT_OWN_TESTS              0  CACHE BOOL   "own tests.")
+
+if (RABBIT_TIME_HASH_MAPS)
+add_executable (time_hash_maps time_hash_maps.cpp)
+target_include_directories (time_hash_maps PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+endif()
+
+if(RABBIT_TESTS)
+add_subdirectory(tests)
+endif()
+
+if(RABBIT_OWN_TESTS)
+add_subdirectory(rabbit_tests)
+endif()

--- a/rabbit/rabbit_map.h
+++ b/rabbit/rabbit_map.h
@@ -207,7 +207,7 @@ namespace rabbit{
 		typedef typename _InMapper::config_type rabbit_config;
 		typedef typename rabbit_config::_Bt _Bt;
 		typedef typename rabbit_config::size_type size_type;
-		typedef ptrdiff_t difference_type;
+		typedef std::ptrdiff_t difference_type;
 		typedef _InMapper _Mapper;
 	};
 	typedef basic_traits<_BinMapper<basic_config<0> > > default_traits;

--- a/rabbit_tests/CMakeLists.txt
+++ b/rabbit_tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required (VERSION 3.1.0)
+project (rabbit)
+
+add_executable (rabbit_test main.cpp)
+enable_testing()
+add_test(NAME rabbit_test COMMAND rabbit_test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories (rabbit_test PUBLIC ${BASE_PATH})

--- a/rabbit_tests/main.cpp
+++ b/rabbit_tests/main.cpp
@@ -8,11 +8,10 @@
 #include <string>
 #include <sstream>
 
-#define _HAS_GOOGLE_HASH_
-#ifdef _MSC_VER
-#endif
 #include <functional>
+#ifdef _HAS_GOOGLE_HASH_
 #include <sparsehash/internal/sparseconfig.h>
+#endif
 
 #include <rabbit/unordered_map>
 #include <rabbit/unordered_set>
@@ -418,7 +417,7 @@ int main(int argc, char **argv)
 #endif
 	size_t ts = 10000000;
 	test_random(ts);
-	google_times(ts);
+	//google_times(ts);
 	//more_tests();
 	return 0;
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+cmake_minimum_required (VERSION 3.1.0)
+project (rabbit)
+
+add_executable (test_ main.cpp)
+enable_testing()
+add_test(NAME test_ COMMAND test WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories (test_ PUBLIC ${BASE_PATH})

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -8,11 +8,11 @@
 #include <string>
 #include <sstream>
 
-#define _HAS_GOOGLE_HASH_
-#ifdef _MSC_VER
-#endif
+
 #include <functional>
+#ifdef _HAS_GOOGLE_HASH_
 #include <sparsehash/internal/sparseconfig.h>
+#endif
 
 #include <rabbit/unordered_map>
 #include <rabbit/unordered_set>


### PR DESCRIPTION
Hey Christian!
After watching your CppCon Talk and and being on the search for a efficient dense hash table I checked out your project. 
I copied it into my project and wanted to use it, but I got immediate compile errors under clang.
Then I took a more systematic approach and first forked the project, cloned it and figured that I wanted to first run your tests under clang, as this would be easier for fixing bugs.
I quickly realized that your project completely lacks a build system if one does not have codelite.
So I started adding cmake.
As I dived deeper I figured out that there are more problems than that. So I had to abandon this due to limited time. 
So as is I am sadly unable to use the rabbit hash table in my project.
I still wanted to share with you my work, if you want to pick up it you have the option.

For me to be able to use it following things would need to happen:
* should compile and run under clang 3.6 - current, gcc 4.8, gcc5 and gcc6 and visual studio 10,13,15 in c++98 and c++11. That can be CI-tested using open source CI systems, for inspiration look at bareflank (https://github.com/Bareflank/hypervisor/) which has CI set up.
* at least some unit test coverage
* a cross-plattform usable build system, e.g. cmake and build / install inscructions (if you want to go the whole way, comply to https://bestpractices.coreinfrastructure.org/)
* build system switches for google dense hash available / not available.
* cleanup of largely duplicate tests and rabbit tests
* not so much commented out code.

Thanks for the nice talk and for the effort you have put in. 